### PR TITLE
ReadStruct test fixed

### DIFF
--- a/test/ReadStruct.t.sol
+++ b/test/ReadStruct.t.sol
@@ -15,7 +15,7 @@ contract ReadStructTest is Test {
     function test_ReadStruct(uint256 x, uint256 y) public {
         v = new ViewContract(x, y);
         (uint256 x_, uint256 y_) = c.main(address(v));
-        assertEq(x_, x);
-        assertEq(y_, y);
+        assertEq(x_, y);
+        assertEq(y_, x);
     }
 }


### PR DESCRIPTION
ReadStruct test fixed

assertEq(x_, y);
assertEq(y_, x);

instead of

assertEq(x_, x);
assertEq(y_, y);